### PR TITLE
Update tables-databases-columns-names.md

### DIFF
--- a/doc_source/tables-databases-columns-names.md
+++ b/doc_source/tables-databases-columns-names.md
@@ -8,7 +8,7 @@ If you are interacting with Apache Spark, then your table names and table column
 
 Queries with mixedCase column names, such as `profileURI`, or upper case column names do not work\.
 
-Similarly, partition names (and the underlying S3 keys) must also be lower case.
+Similarly, partition names and their underlying Amazon S3 keys must also be lower case.
 
 ## Athena table, database, and column names allow only underscore special characters<a name="ate-table-database-and-column-names-allow-only-underscore-special-characters"></a>
 

--- a/doc_source/tables-databases-columns-names.md
+++ b/doc_source/tables-databases-columns-names.md
@@ -8,6 +8,8 @@ If you are interacting with Apache Spark, then your table names and table column
 
 Queries with mixedCase column names, such as `profileURI`, or upper case column names do not work\.
 
+Similarly, partition names (and the underlying S3 keys) must also be lower case.
+
 ## Athena table, database, and column names allow only underscore special characters<a name="ate-table-database-and-column-names-allow-only-underscore-special-characters"></a>
 
 Athena table, database, and column names cannot contain special characters, other than underscore `(_)`\.


### PR DESCRIPTION
*Description of changes:*
Add note to explicitly state that partitions should not use mixed case names. Discovered via AWS Support Case 4943004291.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
