### PR TITLE
Clarify note about .csv.metadata files

### DIFF
--- a/doc_source/querying.md
+++ b/doc_source/querying.md
@@ -6,7 +6,7 @@ Each query that you run has:
 
 + A results file stored automatically in a CSV format \(\*\.csv\), and
 
-+ A metadata file \(`*.csv.metadata`\) that includes header information, such as column type\.
++ An Athena metadata file (`*.csv.metadata`).
 
 If necessary, you can access the result files to work with them\. Athena stores query results in this Amazon S3 bucket by default: `aws-athena-query-results-<ACCOUNTID>-<REGION>`\.
 


### PR DESCRIPTION
This rewords the description of the `.csv.metadata` files to avoid implying that end-users should be able to read these files, which are in a format proprietary to Athena.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
