### PR TITLE
Update DDL statement to fix console error

### DIFF
--- a/doc_source/cloudfront-logs.md
+++ b/doc_source/cloudfront-logs.md
@@ -54,7 +54,7 @@ This procedure works for the Web distribution access logs in CloudFront\. It doe
    )
    ROW FORMAT DELIMITED 
    FIELDS TERMINATED BY '\t'
-   LOCATION 's3:////CloudFront_bucket_name/AWSLogs/Account_ID/'
+   LOCATION 's3://CloudFront_bucket_name/AWSLogs/Account_ID/'
    TBLPROPERTIES ( 'skip.header.line.count'='2' )
    ```
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
When running the previous query in the Athena Console, I see this error:

```
Invalid location s3:////CloudFront_bucket_name/AWSLogs/Account_ID/ for table. Only S3 locations are allowed (Service: AmazonAthena; Status Code: 400; Error Code: InvalidRequestException; Request ID: ed675315-32ae-11e8-bc2a-d1bbb21cee60)
```

Removing 2 `/` characters from the LOCATION fixes this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
