### PR TITLE
Add missing parenthesis in code sample

### DIFF
--- a/doc_source/code-samples.md
+++ b/doc_source/code-samples.md
@@ -134,7 +134,7 @@ public class StartQueryExample
       while (isQueryStillRunning) {
           getQueryExecutionResult = client.getQueryExecution(getQueryExecutionRequest);
           String queryState = getQueryExecutionResult.getQueryExecution().getStatus().getState();
-          if (queryState.equals(QueryExecutionState.FAILED.toString()) {
+          if (queryState.equals(QueryExecutionState.FAILED.toString())) {
               throw new RuntimeException("Query Failed to run with Error Message: " + getQueryExecutionResult.getQueryExecution().getStatus().getStateChangeReason());
           }
           else if (queryState.equals(QueryExecutionState.CANCELLED.toString())) {


### PR DESCRIPTION
waitForQueryToComplete example doesn't compile because it's missing a parenthesis

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
