### PR TITLE
Update the MSCK REPAIR TABLE docs

### DIFF
--- a/doc_source/msck-repair-table.md
+++ b/doc_source/msck-repair-table.md
@@ -1,6 +1,12 @@
 # MSCK REPAIR TABLE<a name="msck-repair-table"></a>
 
-Recovers partitions and data associated with partitions\. Use this statement when you add partitions to the catalog\. It is possible it will take some time to add all partitions\. If this operation times out, it will be in an incomplete state where only a few partitions are added to the catalog\. You should run the statement on the same table until all partitions are added\. For more information, see [Partitioning Data](partitions.md)\.
+Recovers partitions and data associated with partitions\. Use this statement after you create a table for existing partitioned data, or have made significant changes to the data of a partitioned table\.
+
+It is possible it will take some time to add all partitions\. If this operation times out, it will be in an incomplete state where only a few partitions are added to the catalog\. You should run the statement on the same table until all partitions are added\. Alternatively you can add each partition manually with [`ALTER TABLE ADD PARTITION`](alter-table-add-partition.md) to add each partition manually\.
+
+`MSCK REPAIR TABLE` looks for path components with a partition key name and value separated by an equal sign, e.g. `year=2019/month=08/day=10`. If your path layout does not follow this pattern you need to use [`ALTER TABLE ADD PARTITION`](alter-table-add-partition.md) to add each partition manually\.
+
+For more information, see [Partitioning Data](partitions.md)\.
 
 ## Synopsis<a name="synopsis"></a>
 


### PR DESCRIPTION
*Description of changes:*

New Athena users that don't come from the Hive/Presto/Spark world don't know about the Hive style partitioning scheme and will attempt to use MSCK REPAIR TABLE on for example structures created by Kinesis Firehose or CloudTrail. To help people discover the limitations of the command, and what the alternatives are a note about Hive style partitioning is added, and also a note and link to the ALTER TABLE ADD PARTITION command.

A note about only using MSCK REPAIR TABLE to load partitions for new tables, or tables where the partitions have changed significantly is also added, because the command is very slow to run as a way to just add a single partition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.