### PR TITLE
Add new CloudFront attributes

### DIFF
--- a/doc_source/cloudfront-logs.md
+++ b/doc_source/cloudfront-logs.md
@@ -48,11 +48,18 @@ This procedure works for the Web distribution access logs in CloudFront\. It doe
      response_result_type STRING,
      http_version STRING,
      fle_status STRING,
-     fle_encrypted_fields INT
+     fle_encrypted_fields INT,
+     c_port INT,
+     time_to_first_byte FLOAT,
+     x_edge_detailed_result_type STRING,
+     sc_content_type STRING,
+     sc_content_len BIGINT,
+     sc_range_start BIGINT,
+     sc_range_end BIGINT
    )
    ROW FORMAT DELIMITED 
    FIELDS TERMINATED BY '\t'
-   LOCATION 's3://CloudFront_bucket_name/AWSLogs/ACCOUNT_ID/'
+   LOCATION 's3://CloudFront_bucket_name/CloudFront/'
    TBLPROPERTIES ( 'skip.header.line.count'='2' )
    ```
 


### PR DESCRIPTION
Update the table definition for CloudFront to add the 7 new data fields AWS announced https://aws.amazon.com/about-aws/whats-new/2019/12/cloudfront-detailed-logs/
Also fix the S3 bucket format to match CloudFront logs instead of CloudTrail


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
