### PR TITLE
There is no FLOAT type. Rename FLOAT -> REAL in the documentation

### DIFF
--- a/doc_source/data-types.md
+++ b/doc_source/data-types.md
@@ -19,7 +19,7 @@ When you run [CREATE TABLE](create-table.md), you specify column names and the d
   + `BIGINT`\.A 64\-bit signed `INTEGER` in two’s complement format, with a minimum value of \-2^63 and a maximum value of 2^63\-1\.
 + Floating\-point types
   + `DOUBLE`
-  + `FLOAT`
+  + `REAL`
 + Fixed precision type
   + `DECIMAL [ (precision, scale) ]`, where `precision` is the total number of digits, and `scale` \(optional\) is the number of digits in fractional part, the default is 0\. For example, use these type definitions: `DECIMAL(11,5)`, `DECIMAL(15)`\. 
 


### PR DESCRIPTION
*Description of changes:* Using `FLOAT` in Athena I've got `Unknown type: float` exception. After digging around and checking Presto documentation I realised that the name in the documentation is wrong. The correct term is `REAL`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
