### PR TITLE
Fix tblproperties of parquet

### DIFF
--- a/doc_source/parquet.md
+++ b/doc_source/parquet.md
@@ -130,7 +130,7 @@ CREATE EXTERNAL TABLE flight_delays_pq (
 PARTITIONED BY (year STRING)
 STORED AS PARQUET
 LOCATION 's3://athena-examples-myregion/flight/parquet/'
-tblproperties ("parquet.compress"="SNAPPY");
+tblproperties ("parquet.compression"="SNAPPY");
 ```
 
 Run the `MSCK REPAIR TABLE` statement on the table to refresh partition metadata:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* To set the compression algorithm correctly, specify `parquet.compression`.
I tried both `"parquet.compress"="SNAPPY"` and `"parquet.compression"="SNAPPY"` on athena. Only the latter setting was SNAPPY compressed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
