### PR TITLE
Use the same table in both scenarios

### DIFF
--- a/doc_source/partitions.md
+++ b/doc_source/partitions.md
@@ -117,7 +117,7 @@ This query should show you data similar to the following:
 2009-04-12-13-20    b31tJiIA25CK8eDHQrHnbcknfSndUk
 ```
 
-### Scenario 2: Data is not partitioned<a name="scenario-2-data-is-not-partitioned"></a>
+### Scenario 2: Data is not partitioned in Hive format<a name="scenario-2-data-is-not-partitioned"></a>
 
 A layout like the following does not, however, work for automatically adding partition data with MSCK REPAIR TABLE:
 
@@ -182,7 +182,7 @@ In this case, you would have to use ALTER TABLE ADD PARTITION to add each partit
 For example, to load the data in s3://athena\-examples\-*myregion*/elb/plaintext/2015/01/01/, you can run the following:
 
 ```
-ALTER TABLE elb_logs_raw_native_part ADD PARTITION (year='2015',month='01',day='01') location 's3://athena-examples-us-west-1/elb/plaintext/2015/01/01/'
+ALTER TABLE elb_logs_raw_native_part ADD PARTITION (dt='2015-01-01') location 's3://athena-examples-us-west-1/elb/plaintext/2015/01/01/'
 ```
 
 ### Additional Resources<a name="partitions-additional-resources"></a>


### PR DESCRIPTION
The first scenario shows the schema of a table, but the second scenario doesn't. For some reason the second scenario assumes a different table schema, which is confusing.

Changing the second scenario to assume the same table schema as the first scenario makes the examples work better together, and contrast the benefits and downsides of both approaches.

Using a single partition key in the second scenario also shows that you don't have to have a separate partition column per S3 "directory", and that the partition key value can be different from the S3 key, which is something that isn't at all clear from the example as it is now.

Also change the heading to not imply that the data in the second scenario isn't partitioned. It is partitioned, it's just not partitioned in the Hive style. The heading of the first scenario makes it clear that it describes Hive style partitioning, and the second scenario should make it clearer that it describes an alternative style, not a lack of partitioning (that's something entirely different).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
