### PR TITLE
Add a query example to the partition projection docs

### DIFF
--- a/doc_source/partition-projection-kinesis-firehose-example.md
+++ b/doc_source/partition-projection-kinesis-firehose-example.md
@@ -11,10 +11,13 @@ Normally, to use Athena to query Kinesis Data Firehose data without using partit
 By using partition projection, you can use a one\-time configuration to inform Athena where the partitions reside\. The following `CREATE TABLE` example assumes a start date of 2018\-01\-01 at midnight\. Note the use of `NOW` for the upper boundary of the date range, which allows new data to automatically become queryable at the appropriate UTC time\. 
 
 ```
+CREATE EXTERNAL TABLE my_table
+(
 ...
+)
 PARTITIONED BY
 (
- DATEHOUR STRING
+ datehour STRING
 )
 LOCATION "s3://bucket/prefix/"
 TBLPROPERTIES
@@ -27,4 +30,13 @@ TBLPROPERTIES
  "projection.datehour.interval.unit" = "HOURS",
  "storage.location.template" = "s3://bucket/prefix/${datehour}"
 )
+```
+
+With this table you can run queries like the following, without having to manually add partitions:
+
+```
+SELECT *
+FROM my_table
+WHERE datehour >= '2018/02/03/00'
+AND datehour < '2018/02/03/04'
 ```


### PR DESCRIPTION
This adds a query as an example of how to use the table created in the Firehose example in the partition projection documentation.

When reading through the partition projection docs, one thing that wasn't immediately clear to me how much magic was going on when the projection type is "date". I was somehow expecting it to allow me to use dates in queries, which would be formatted using the configured format. By adding this example I hope that other people will get how it actually works faster than I did.

In other words, after my first reading I expected this query to be possible: `SELECT * FROM my_table WHERE datehour = DATE '2018-02-03 10:00'`, but in fact, what happens is rather that the values for the partition key `datehour` have to be literally what gets interpolated into the `storage.location.template`.

This change also adds a name to the example table (because that was needed to make the query example connect to the DDL above it), and also lower cases the name of the column in the DDL for consistency (it was upper case in the partition key section, but lower case in the table properties).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
