### PR TITLE
Update the DATE and TIMESTAMP data type docs

### DIFF
--- a/doc_source/data-types.md
+++ b/doc_source/data-types.md
@@ -26,8 +26,8 @@ To use the `substr` function to return a substring of specified length from a `C
 **Note**  
 Non\-string data types cannot be cast to `STRING` in Athena; cast them to `VARCHAR` instead\.
 + **`BINARY`** – Used for data in Parquet\.
-+ **`DATE`** – A date in UNIX format, such as `YYYY-MM-DD`\.
-+ **`TIMESTAMP`** – Date and time instant in the UNiX format, such as `yyyy-mm-dd hh:mm:ss[.f...]`\. For example, `TIMESTAMP '2008-09-15 03:04:05.324'`\. This format uses the session time zone\.
++ **`DATE`** – A date in ISO format, such as `yyyy-mm-dd`\. For example `DATE '2008-09-15'`\.
++ **`TIMESTAMP`** – Date and time instant in a `java.sql.Timestamp` compatible format such as `yyyy-mm-dd hh:mm:ss[.f...]`\. For example `TIMESTAMP '2008-09-15 03:04:05.324'`\. This format uses the session time zone\.
 + **`ARRAY`**`<data_type>`
 + **`MAP`**`<primitive_type, data_type>`
 + **`STRUCT`**`<col_name : data_type [COMMENT col_comment] , ...>`


### PR DESCRIPTION
The `DATE` and `TIMESTAMP` formats are _not_ examples of "UNiX format" (weird and inconsistent capitalization or no). The date format would best be described as ISO standard format, while the timestamp format is (at least according to the OpenCSVSerDe page in the Athena documentation) an example of the format expected by `java.sql.Timestamp` (and consequently Hive, I would assume).

I also made sure that the two entries look more consistent by using the same capitalisation for the format string, and that both have examples.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
