### PR TITLE
Fixed the Amazon Athena Neptune Connector link

### DIFF
--- a/doc_source/athena-prebuilt-data-connectors-neptune.md
+++ b/doc_source/athena-prebuilt-data-connectors-neptune.md
@@ -4,4 +4,4 @@ Amazon Neptune is a fast, reliable, fully managed graph database service that ma
 
 The Amazon Athena Neptune Connector enables Athena to communicate with your Neptune graph database instance, making your Neptune graph data accessible by SQL queries\.
 
-For information about configuration options, permissions, deployment, performance, and limitations, see [Amazon Athena Neptune Connector](https://github.com/awslabs/aws-athena-query-federation/tree/master/athena-redis) on GitHub\.
+For information about configuration options, permissions, deployment, performance, and limitations, see [Amazon Athena Neptune Connector](https://github.com/awslabs/aws-athena-query-federation/tree/master/athena-neptune) on GitHub\.


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Modified the link to Athena Neptune Connector to point to the right GitHub location.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
