### PR TITLE
Syntax for bucket_by and partition_by are actually the same

### DIFF
--- a/doc_source/create-table-as.md
+++ b/doc_source/create-table-as.md
@@ -55,9 +55,9 @@ s3://<query-results-location-setting>/<Unsaved-or-query-name>/<year>/<month/<dat
 ```  
 `format = [format]`  
 The data format for the CTAS query results, such as `ORC`, `PARQUET`, `AVRO`, `JSON`, or `TEXTFILE`\. For example, `WITH (format = 'PARQUET')`\. If omitted, `PARQUET` is used by default\. The name of this parameter, `format`, must be listed in lowercase, or your CTAS query will fail\.  
-`partitioned_by = ARRAY( [col_name,…])`  
+`partitioned_by = ARRAY[ [col_name,…] ]`  
 Optional\. An array list of columns by which the CTAS table will be partitioned\. Verify that the names of partitioned columns are listed last in the list of columns in the `SELECT` statement\.   
-`bucketed_by( [bucket_name,…])`  
+`bucketed_by = ARRAY[ [bucket_name,…] ]`  
 An array list of buckets to bucket data\. If omitted, Athena does not bucket your data in this query\.  
 `bucket_count = [int]`  
 The number of buckets for bucketing your data\. If omitted, Athena does not bucket your data\.  


### PR DESCRIPTION
Confusingly the docs suggest that bucket_by and partition_by have different syntax, but they do not. They also suggested parameters of the array should be in parenthesis () instead of brackets [].

Issue #59

Changes are pretty self descriptive.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
