### PR TITLE
Whitespace typo

### DIFF
--- a/doc_source/alter-table-add-columns.md
+++ b/doc_source/alter-table-add-columns.md
@@ -31,7 +31,7 @@ ALTER TABLE events PARTITION (awsregion='us-west-2') ADD COLUMNS (event string)
 ```
 
 ```
-ALTER TABLE events PARTITION (awsregion='us- west-2') ADD COLUMNS (eventdescription string)
+ALTER TABLE events PARTITION (awsregion='us-west-2') ADD COLUMNS (eventdescription string)
 ```
 
 ## Notes<a name="alter-table-add-columns-notes"></a>


### PR DESCRIPTION
*Description of changes:*

There is a trivial typo in a region name, no further changes in this PR.