### PR TITLE
Update querying-r53-resolver-logs.md

### DIFF
--- a/doc_source/querying-r53-resolver-logs.md
+++ b/doc_source/querying-r53-resolver-logs.md
@@ -37,7 +37,7 @@ You can use the Query Editor in the Athena console to create and query a table f
      transport string,
      srcids struct<
        instance: string,
-       resolverEndpoint: string
+       resolver_endpoint: string
        >
     )
         


### PR DESCRIPTION
Cx ran into this issue with the example being incorrect, updated to the correct variable the cx was able to use to retrieve the info. Not familiar with Athena, so please feel free to adjust as needed but this was the matching field in the resolver logs and the cx was able to use it to pull the info properly.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
