### PR TITLE
Update data-types.md

### DIFF
--- a/doc_source/data-types.md
+++ b/doc_source/data-types.md
@@ -27,7 +27,7 @@ To use the `substr` function to return a substring of specified length from a `C
 Non\-string data types cannot be cast to `STRING` in Athena; cast them to `VARCHAR` instead\.
 + **`BINARY`** – Used for data in Parquet\.
 + **`DATE`** – A date in ISO format, such as `YYYY-MM-DD`\. For example, `DATE '2008-09-15'`\.
-+ **`TIMESTAMP`** – Date and time instant in a [https://docs.oracle.com/javase/8/docs/api/java/sql/Timestamp.html](https://docs.oracle.com/javase/8/docs/api/java/sql/Timestamp.html) compatible format, such as `yyyy-MM-dd HH:mm:ss[.f...]`\. For example, `TIMESTAMP '2008-09-15 03:04:05.324'`\.
++ **`TIMESTAMP`** – Date and time instant in a [https://docs.oracle.com/javase/8/docs/api/java/sql/Timestamp.html](https://docs.oracle.com/javase/8/docs/api/java/sql/Timestamp.html) compatible format up to a maximum resolution of milliseconds, such as `yyyy-MM-dd HH:mm:ss[.f...]`\. For example, `TIMESTAMP '2008-09-15 03:04:05.324'`\.
 + **`ARRAY`**`<data_type>`
 + **`MAP`**`<primitive_type, data_type>`
 + **`STRUCT`**`<col_name : data_type [COMMENT col_comment] , ...>`


### PR DESCRIPTION
This is misleading. TIMESTAMP only supports millisecond resolution while java.sql.timestamp supports nanosecond resolution, such that

java.sql.Timestamp.valueOf("2007-09-23 10:10:10.123456"); 

is valid while

SELECT CAST('2007-09-23 10:10:10.123456' as timestamp);

throws an INVALID_CAST_ARGUMENT error on Athena.

*Description of changes:*

Change description to be explicit as to what it supports.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
