### PR TITLE
Update show-tables.md

### DIFF
--- a/doc_source/show-tables.md
+++ b/doc_source/show-tables.md
@@ -37,7 +37,7 @@ view_2016_flights_dfw
 **Example – show the names of all tables in `sampledb` that include the word "flights"**  
 
 ```
-SHOW TABLES IN sampledb '*flights*'
+SHOW TABLES IN sampledb '.*flights.*'
 ```
 Results  
 
@@ -50,7 +50,7 @@ view_2016_flights_dfw
 **Example – show the names of all tables in `sampledb` that end in the word "logs"**  
 
 ```
-SHOW TABLES IN sampledb '*logs'
+SHOW TABLES IN sampledb '.*logs'
 ```
 Results  
 


### PR DESCRIPTION
The syntax for the regular expression is incorrect.
If you run the command currently shown in the doc  SHOW TABLES IN sampledb '*flights*' , you will get the following error:
Execution Error, return code 1 from org.apache.hadoop.hive.ql.exec.DDLTask. MetaException(message:Failed to get table names with pattern *flights* in DB sampledb. java.io.IOException: java.lang.RuntimeException: java.util.regex.PatternSyntaxException: Dangling meta character '*' near index 0
We need add a . before each *, like described in manual for the SHOW DATABASES command (here https://docs.aws.amazon.com/athena/latest/ug/show-databases.html)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
