### PR TITLE
change elb_status_code type to int

### DIFF
--- a/doc_source/application-load-balancer-logs.md
+++ b/doc_source/application-load-balancer-logs.md
@@ -28,7 +28,7 @@ The following `CREATE TABLE` statement includes the recently added `classificati
                request_processing_time double,
                target_processing_time double,
                response_processing_time double,
-               elb_status_code string,
+               elb_status_code int,
                target_status_code string,
                received_bytes bigint,
                sent_bytes bigint,


### PR DESCRIPTION
so we can now perform queries like `elb_status_code >= 500` rather than `elb_status_code in (500, 502, 504...`
