### PR TITLE
Fix temp table name in first query example (WAF)

### DIFF
--- a/doc_source/waf-logs.md
+++ b/doc_source/waf-logs.md
@@ -238,7 +238,7 @@ WITH test_dataset AS
     CROSS JOIN UNNEST(httprequest.headers) AS t(header) WHERE day >= '2021/03/01'
     AND day < '2021/03/31')
 SELECT COUNT(*) referer_count 
-FROM DATASET 
+FROM test_dataset 
 WHERE LOWER(header.name)='referer' AND header.value LIKE '%amazon%'
 ```
 


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Temp table [defined](https://github.com/awsdocs/amazon-athena-user-guide/blob/main/doc_source/waf-logs.md?plain=1#L236) as `test_dataset`, but we trying to query `DATASET` in [`FROM`](https://github.com/awsdocs/amazon-athena-user-guide/blob/main/doc_source/waf-logs.md?plain=1#L241). So, this doesn't work. 

It's `test_dataset` everywhere in other examples with temp tables, so it would make sense to rename it to `test_dataset` in `FROM` line.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
