### PR TITLE
include the actual error code TooManyRequestsException so this is ind…

### DIFF
--- a/doc_source/service-limits.md
+++ b/doc_source/service-limits.md
@@ -15,7 +15,7 @@ These are soft quotas; you can use the [Athena Service Quotas](https://console.a
 
 Athena processes queries by assigning resources based on the overall service load and the number of incoming requests\. Your queries may be temporarily queued before they run\. Asynchronous processes pick up the queries from queues and run them on physical resources as soon as the resources become available and for as long as your account configuration permits\.
 
-A DML or DDL query quota includes both running and queued queries\. For example, if you are using the default DML quota and your total of running and queued queries exceeds 25, query 26 will result in a "too many queries" error\. 
+A DML or DDL query quota includes both running and queued queries\. For example, if you are using the default DML quota and your total of running and queued queries exceeds 25, query 26 will result in a "TooManyRequestsException" error\. 
 
 ### Query String Length<a name="service-limits-query-string-length"></a>
 


### PR DESCRIPTION
…exed by search engines

Current doc explains the error but doesn't include the exact error code.  By including "TooManyRequestsException" this makes it simpler for customers to find the page when the encounter the error.

*Issue #, if available:*

*Description of changes:*
Here is the error message full contents for reference

TooManyRequestsException: An error occurred (TooManyRequestsException) when calling the StartQueryExecution operation: You have exceeded the limit for the number of queries you can run concurrently. Please reduce the number of concurrent queries submitted by this account. Contact customer support to request a concurrent query limit increase.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
