### PR TITLE
Update cloudtrail-serde.md

### DIFF
--- a/doc_source/cloudtrail-serde.md
+++ b/doc_source/cloudtrail-serde.md
@@ -22,7 +22,7 @@ In addition to using the CloudTrail SerDe, instances exist where you need to use
 
 The following example uses the CloudTrail SerDe on a fictional set of logs to create a table based on them\.
 
-In this example, the fields `requestParameters`, `responseElements`, and `additionalEventData` are included as part of `STRUCT` data type used in JSON\. To get data out of these fields, use `JSON_EXTRACT` functions\. For more information, see [Extracting data from JSON](extracting-data-from-JSON.md)\.
+In this example, the fields `requestParameters`, `responseElements`, and `additionalEventData` are included as part of `STRING` data type used in JSON\. To get data out of these fields, use `JSON_EXTRACT` functions\. For more information, see [Extracting data from JSON](extracting-data-from-JSON.md)\.
 
 ```
 CREATE EXTERNAL TABLE cloudtrail_logs (


### PR DESCRIPTION
Updating incorrectly described data type.

*Issue #, if available:*
None

*Description of changes:*
It seems to me that the description of the data type for the `requestParameters`, `responseElements`, and `additionalEventData` is incorrect. The type definitions in the table as well as the suggestion to use `JSON_EXTRACT` appear to line up with the assumption that this sentence meant to use the word `STRING` instead of `STRUCT`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
