### PR TITLE
Fix the location for flowlogs in Apache Parquet format

### DIFF
--- a/doc_source/vpc-flow-logs.md
+++ b/doc_source/vpc-flow-logs.md
@@ -190,14 +190,14 @@ The following procedure creates an Amazon VPC table for Amazon VPC flow logs in 
    OUTPUTFORMAT 
      'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
    LOCATION
-     's3://DOC-EXAMPLE-BUCKET/parquet/AWSLogs/aws-account-id=account_id/aws-service=vpcflowlogs/aws-region=region_code/'
+     's3://DOC-EXAMPLE-BUCKET/prefix/AWSLogs/'
    TBLPROPERTIES (
      'EXTERNAL'='true', 
      'skip.header.line.count'='1'
      )
    ```
 
-1. Modify the sample `LOCATION 's3://DOC-EXAMPLE-BUCKET/parquet/AWSLogs/aws-account-id=account_id/aws-service=vpcflowlogs/aws-region=region_code/' ` to point to the Amazon S3 path that contains your log data\.
+1. Modify the sample `LOCATION 's3://DOC-EXAMPLE-BUCKET/prefix/AWSLogs/' ` to point to the Amazon S3 path that contains your log data\.
 
 1. Run the query in Athena console\.
 


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
It seems that the location is incorrectly specified for flowlogs in Apache Parquet format.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
