### PR TITLE
docs: clarify access control for s3

### DIFF
--- a/doc_source/s3-permissions.md
+++ b/doc_source/s3-permissions.md
@@ -1,6 +1,8 @@
 # Access to Amazon S3<a name="s3-permissions"></a>
 
-You can grant access to Amazon S3 locations using identity\-based policies, bucket resource policies, access point policies, or any combination of the above\. 
+You can grant access to Amazon S3 locations using identity\-based policies, bucket resource policies, access point policies, or any combination of the above\.
+
+When actors interact with Athena, their permissions pass through Athena to determine what Athena can access. This means that users must have permission to access S3 buckets in order to query them with Athena.
 
 Whenever you use IAM policies, make sure that you follow IAM best practices\. For more information, see [Security best practices in IAM](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html) in the *IAM User Guide*\.
 


### PR DESCRIPTION
*Description of changes:* if you're just trying to understand Athena from a security perspective, it's not obvious how Athena interacts with IAM in practice. The documentation that actually explains this is not in the "Access to Amazon S3" page, and is instead in the ["Creating tables in Athena" page](https://docs.aws.amazon.com/athena/latest/ug/creating-tables.html?icmpid=docs_console_unmapped#s3-considerations).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.