### PR TITLE
Replace backslashes with slashes for S3 path

### DIFF
--- a/doc_source/notebooks-spark-adding-jar-files.md
+++ b/doc_source/notebooks-spark-adding-jar-files.md
@@ -55,7 +55,7 @@ The following procedure shows how to add a JAR file from Amazon S3 to your noteb
    }
    ```
 
-1. Build the Java `custom-UDF1.jar` file, and then upload it to your own location in Amazon S3 \(for example, `s3:\\DOC-EXAMPLE-BUCKET\custom-UDF1.jar`\)\.
+1. Build the Java `custom-UDF1.jar` file, and then upload it to your own location in Amazon S3 \(for example, `s3://DOC-EXAMPLE-BUCKET/custom-UDF1.jar`\)\.
 
 1. In your Athena for Spark notebook, run the following commands\. Make sure that you use the `s3a://` scheme for `add jar`\.
 


### PR DESCRIPTION
I noticed possible the wrong usage of backslashes in the documentation, so it looks to me it should be changed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
